### PR TITLE
sunstatus changed to int for grafana

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ var getForecast = function () {
             var current = forecast.currently;
             var daily = forecast.daily.data[0];
             var moment = (new Date()).getTime() / 1000;
-            var sunStatus = False;
+            var sunStatus = new Boolean(0);
 
             if (generalConfig.debug) {
                 console.log("Sunrise: ", daily.sunriseTime);
@@ -74,7 +74,7 @@ var getForecast = function () {
             }
 
             if(moment > daily.sunriseTime && moment < daily.sunsetTime)
-                sunStatus = True;
+                sunStatus = true;
 
             if (generalConfig.debug)
                 console.log("Sun Status: ", sunStatus);

--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ var getForecast = function () {
             var current = forecast.currently;
             var daily = forecast.daily.data[0];
             var moment = (new Date()).getTime() / 1000;
-            var sun_status = 0;
+            var sunStatus = 0;
 
             if (generalConfig.debug) {
                 console.log("Sunrise: ", daily.sunriseTime);
@@ -74,10 +74,10 @@ var getForecast = function () {
             }
 
             if(moment > daily.sunriseTime && moment < daily.sunsetTime)
-                sun_status = 1;
+                sunStatus = 1;
 
             if (generalConfig.debug)
-                console.log("Sun Status: ", sun_status);
+                console.log("Sun Status: ", sunStatus);
 
             const points = [
                 {
@@ -101,7 +101,7 @@ var getForecast = function () {
 
                         sunrise_time: daily.sunriseTime,
                         sunset_time: daily.sunsetTime,
-                        sun: sun_status,
+                        sun: sunStatus,
                     },
                     tags: {
                         source: 'darksky'

--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 const Influx = require('influx'),
     config = require('config'),
     cron = require('node-cron'),
-    DarkSky = require('darksky-node/lib/darksky-api')
+    DarkSky = require('darksky-node/lib/darksky-api'),
+    moment = require('moment')
 
 const generalConfig = config.get('general'),
     influxConfig = config.get('influxdb'),
@@ -31,10 +32,15 @@ const influx = new Influx.InfluxDB({
                 cloud_cover: Influx.FieldType.FLOAT,
                 pressure: Influx.FieldType.FLOAT,
                 ozone: Influx.FieldType.FLOAT,
+                uv_index: Influx.FieldType.FLOAT,
+                visibility: Influx.FieldType.FLOAT,
                 precip_intensity: Influx.FieldType.FLOAT,
                 precip_probability: Influx.FieldType.FLOAT,
                 nearest_storm_distance: Influx.FieldType.FLOAT,
-                nearest_storm_bearing: Influx.FieldType.FLOAT
+                nearest_storm_bearing: Influx.FieldType.FLOAT,
+                sunrise_time: Influx.FieldType.INTEGER,
+                sunset_time: Influx.FieldType.INTEGER,
+                sun: Influx.FieldType.BOOLEAN
             }
         }
     ]
@@ -44,7 +50,7 @@ const darksky = new DarkSky(darkskyConfig.key);
 
 var getForecast = function () {
     darksky.forecast(darkskyConfig.latitude, darkskyConfig.longitude, {
-        exclude: ['minutely', 'hourly', 'daily', 'alerts', 'flags'],
+        exclude: ['minutely', 'hourly', 'alerts', 'flags'],
         units: darkskyConfig.units
     }, function (err, responseBody) {
         if (err) {
@@ -58,6 +64,21 @@ var getForecast = function () {
             }
 
             var current = forecast.currently;
+            var daily = forecast.daily.data[0];
+            var sun_status = 0;
+
+            if (generalConfig.debug) {
+                console.log("Sunrise: ", daily.sunriseTime);
+                console.log("Sunset: ", daily.sunsetTime);
+                console.log("Now: ", moment().unix());
+            }
+
+            if(moment().unix() > daily.sunriseTime && moment().unix() < daily.sunsetTime)
+                sun_status = 1;
+
+            if (generalConfig.debug)
+                console.log("Sun Status: ", sun_status);
+
             const points = [
                 {
                     measurement: 'weather',
@@ -71,10 +92,16 @@ var getForecast = function () {
                         cloud_cover: current.cloudCover,
                         pressure: current.pressure,
                         ozone: current.ozone,
+                        uv_index: current.uvIndex,
+                        visibility: current.visibility,
                         precip_intensity: current.precipIntensity,
                         precip_probability: current.precipProbability,
                         nearest_storm_distance: current.nearestStormDistance,
                         nearest_storm_bearing: current.nearestStormBearing,
+
+                        sunrise_time: daily.sunriseTime,
+                        sunset_time: daily.sunsetTime,
+                        sun: sun_status,
                     },
                     tags: {
                         source: 'darksky'

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const Influx = require('influx'),
     config = require('config'),
     cron = require('node-cron'),
-    DarkSky = require('darksky-node/lib/darksky-api'),
+    DarkSky = require('darksky-node/lib/darksky-api')
 
 const generalConfig = config.get('general'),
     influxConfig = config.get('influxdb'),

--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ var getForecast = function () {
             var current = forecast.currently;
             var daily = forecast.daily.data[0];
             var moment = (new Date()).getTime() / 1000;
-            var sunStatus = False;
+            var sunStatus = 0;
 
             if (generalConfig.debug) {
                 console.log("Sunrise: ", daily.sunriseTime);
@@ -74,7 +74,7 @@ var getForecast = function () {
             }
 
             if(moment > daily.sunriseTime && moment < daily.sunsetTime)
-                sunStatus = True;
+                sunStatus = 1;
 
             if (generalConfig.debug)
                 console.log("Sun Status: ", sunStatus);

--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ var getForecast = function () {
             var current = forecast.currently;
             var daily = forecast.daily.data[0];
             var moment = (new Date()).getTime() / 1000;
-            var sunStatus = 0;
+            var sunStatus = False;
 
             if (generalConfig.debug) {
                 console.log("Sunrise: ", daily.sunriseTime);
@@ -74,7 +74,7 @@ var getForecast = function () {
             }
 
             if(moment > daily.sunriseTime && moment < daily.sunsetTime)
-                sunStatus = 1;
+                sunStatus = True;
 
             if (generalConfig.debug)
                 console.log("Sun Status: ", sunStatus);

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@ const Influx = require('influx'),
     config = require('config'),
     cron = require('node-cron'),
     DarkSky = require('darksky-node/lib/darksky-api'),
-    moment = require('moment')
 
 const generalConfig = config.get('general'),
     influxConfig = config.get('influxdb'),
@@ -65,15 +64,16 @@ var getForecast = function () {
 
             var current = forecast.currently;
             var daily = forecast.daily.data[0];
+            var moment = (new Date()).getTime() / 1000;
             var sun_status = 0;
 
             if (generalConfig.debug) {
                 console.log("Sunrise: ", daily.sunriseTime);
                 console.log("Sunset: ", daily.sunsetTime);
-                console.log("Now: ", moment().unix());
+                console.log("Now: ", moment);
             }
 
-            if(moment().unix() > daily.sunriseTime && moment().unix() < daily.sunsetTime)
+            if(moment > daily.sunriseTime && moment < daily.sunsetTime)
                 sun_status = 1;
 
             if (generalConfig.debug)

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ const influx = new Influx.InfluxDB({
                 nearest_storm_bearing: Influx.FieldType.FLOAT,
                 sunrise_time: Influx.FieldType.INTEGER,
                 sunset_time: Influx.FieldType.INTEGER,
-                sun: Influx.FieldType.BOOLEAN
+                sun_status: Influx.FieldType.INTEGER
             }
         }
     ]
@@ -65,7 +65,7 @@ var getForecast = function () {
             var current = forecast.currently;
             var daily = forecast.daily.data[0];
             var moment = (new Date()).getTime() / 1000;
-            var sunStatus = new Boolean(0);
+            var sunStatus = 0;
 
             if (generalConfig.debug) {
                 console.log("Sunrise: ", daily.sunriseTime);
@@ -74,7 +74,7 @@ var getForecast = function () {
             }
 
             if(moment > daily.sunriseTime && moment < daily.sunsetTime)
-                sunStatus = true;
+                sunStatus = 1;
 
             if (generalConfig.debug)
                 console.log("Sun Status: ", sunStatus);
@@ -101,7 +101,7 @@ var getForecast = function () {
 
                         sunrise_time: daily.sunriseTime,
                         sunset_time: daily.sunsetTime,
-                        sun: sunStatus,
+                        sun_status: sunStatus,
                     },
                     tags: {
                         source: 'darksky'

--- a/package.json
+++ b/package.json
@@ -23,10 +23,11 @@
   },
   "homepage": "https://github.com/ErwinSteffens/darksky-influxdb#readme",
   "dependencies": {
-    "config": "^1.25.1",
+    "config": "^1.31.0",
     "darksky-node": "0.0.2",
-    "influx": "^5.0.4",
-    "js-yaml": "^3.8.1",
-    "node-cron": "^1.1.3"
+    "influx": "^5.4.1",
+    "js-yaml": "^3.13.1",
+    "moment": "^2.24.0",
+    "node-cron": "^1.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "darksky-node": "0.0.2",
     "influx": "^5.4.1",
     "js-yaml": "^3.13.1",
-    "moment": "^2.24.0",
     "node-cron": "^1.2.1"
   }
 }


### PR DESCRIPTION
DarkSky data will be written to InfluxDB on cron interval '*/10 * * * *'
/usr/src/app/node_modules/influx/lib/src/schema.js:58
throw new Error(Expected boolean value for ${this._ref(field)}, but got a ${typ}!);
^

Error: Expected boolean value for weather_home.weather.sun, but got a number!
at _fieldNames.forEach.field (/usr/src/app/node_modules/influx/lib/src/schema.js:58:31)
at Array.forEach (native)
at Schema.coerceFields (/usr/src/app/node_modules/influx/lib/src/schema.js:29:26)
at points.forEach.point (/usr/src/app/node_modules/influx/lib/src/index.js:824:49)
at Array.forEach (native)
at InfluxDB.writePoints (/usr/src/app/node_modules/influx/lib/src/index.js:821:16)
at /usr/src/app/index.js:112:20
at Request._callback (/usr/src/app/node_modules/darksky-node/lib/darksky-api.js:31:13)
at Request.self.callback (/usr/src/app/node_modules/request/request.js:185:22)
at emitTwo (events.js:106:13)